### PR TITLE
Preserve Mario's level state when switching scenes via portal

### DIFF
--- a/ItemBox.h
+++ b/ItemBox.h
@@ -35,5 +35,4 @@ public:
 
 	float getX() { return x; }
 	float getY() { return y; }
-	int GetType() override { return 9999; }
 };

--- a/Mario.cpp
+++ b/Mario.cpp
@@ -28,6 +28,8 @@
 #include "ItemBoxEffect.h"
 #include "HUD.h"
 
+int CMario::savedLevel = MARIO_LEVEL_SMALL;
+
 void CMario::Update(DWORD dt, vector<LPGAMEOBJECT>* coObjects)
 {
   DebugOut(L"Mario vx: %f\n", vx);
@@ -400,7 +402,8 @@ void CMario::OnCollisionWithCoin(LPCOLLISIONEVENT e)
 
 void CMario::OnCollisionWithPortal(LPCOLLISIONEVENT e)
 {
-	SetAutoWalking(false); 
+	SetAutoWalking(false);
+	CMario::savedLevel = level;
 	CPortal* p = (CPortal*)e->obj;
 	CGame::GetInstance()->InitiateSwitchScene(p->GetSceneId());
 }

--- a/Mario.h
+++ b/Mario.h
@@ -212,7 +212,6 @@ protected:
 	ULONGLONG flyingDuration = 0;
 	bool isAutoWalking = false;
 	CGameObject* stickingObj = nullptr; 
-
 public:
 	CMario(float x, float y) : CGameObject(x, y)
 	{
@@ -297,4 +296,5 @@ public:
 	void SetIsStickToPlatform(CGameObject* obj) { stickingObj = obj; }
 	bool IsStickToPlatform() const { return stickingObj != nullptr; }
 	void SetIsOnPlatform(bool value) { isOnPlatform = value; }
+	static int savedLevel;
 };

--- a/PlayScene.cpp
+++ b/PlayScene.cpp
@@ -130,7 +130,7 @@ void CPlayScene::_ParseSection_OBJECTS(string line)
 		}
 		obj = new CMario(x, y);
 		player = (CMario*)obj;
-
+		((CMario*)player)->SetLevel(CMario::savedLevel);
 		DebugOut(L"[INFO] Player object has been created!\n");
 		break;
 	case OBJECT_TYPE_GOOMBA:

--- a/mario-sample.txt
+++ b/mario-sample.txt
@@ -1,5 +1,5 @@
 [SETTINGS]
-start	1
+start	5
 width	320
 height	240
 


### PR DESCRIPTION
- Added static variable `savedLevel` to CMario to store current level
- Saved Mario's level before scene switch in OnCollisionWithPortal
- Restored saved level when recreating Mario in the new scene
- Ensures Mario keeps small/big/raccoon form across maps